### PR TITLE
Fix/catch no param

### DIFF
--- a/esotope.js
+++ b/esotope.js
@@ -1860,8 +1860,12 @@ var StmtRawGen = {
             $body      = $stmt.body,
             prevIndent = shiftIndent();
 
-        _.js += 'catch' + _.optSpace + '(';
-        ExprGen[$param.type]($param, Preset.e5);
+        _.js += 'catch' + _.optSpace;
+        
+        if ($param) {
+           _.js += '(';
+           ExprGen[$param.type]($param, Preset.e5);
+        }
 
         if ($guard) {
             _.js += ' if ';
@@ -1869,7 +1873,11 @@ var StmtRawGen = {
         }
 
         _.indent = prevIndent;
-        _.js += ')' + adoptionPrefix($body);
+        if ($param) {
+           _.js += ')';
+        } 
+     
+        _.js += adoptionPrefix($body);
         StmtGen[$body.type]($body, Preset.s7);
     },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esotope-hammerhead",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "",
   "main": "esotope.js",
   "files": [


### PR DESCRIPTION
Fixes an issue with catch called without param that make any request to fail with `type of undefined`.
Bumped version to `0.5.6`