### PR TITLE
Update esotope.js

### DIFF
--- a/esotope.js
+++ b/esotope.js
@@ -1531,7 +1531,7 @@ var ExprRawGen = {
             var lastPropIdx = propCount - 1,
                 multiline   = false;
 
-            if (propCount === 1)
+            if (propCount === 1 && $props[0].value)
                 multiline = $props[0].value.type !== Syntax.Identifier;
 
             else {


### PR DESCRIPTION
When https://abs.twimg.com/responsive-web/client-web/main.f6ffe885.js script is ran through Hammerheads's Acorn and generated with this version of Esotope. An error occurs because `$props[0].value` is undefined, and `type` is trying to be retrieved from it as a object property. I've added in one small precaution to make sure this does not happen. 

```
TypeError: Cannot read property 'type' of undefined
    at Object.generateObjectPattern [as ObjectPattern] (D:\Development\unblock\node_modules\esotope-hammerhead\esotope.js:1535:45)
    at generateFunctionParams (D:\Development\unblock\node_modules\esotope-hammerhead\esotope.js:700:37)
    at generateFunctionBody (D:\Development\unblock\node_modules\esotope-hammerhead\esotope.js:713:5)
    at Object.generateArrowFunctionExpression [as ArrowFunctionExpression] (D:\Development\unblock\node_modules\esotope-hammerhead\esotope.js:1143:9)
    at Object.generateConditionalExpression [as ConditionalExpression] (D:\Development\unblock\node_modules\esotope-hammerhead\esotope.js:1177:30)
    at Object.generateConditionalExpression [as ConditionalExpression] (D:\Development\unblock\node_modules\esotope-hammerhead\esotope.js:1179:27)
    at exprToJs (D:\Development\unblock\node_modules\esotope-hammerhead\esotope.js:2433:24)
    at Object.generateReturnStatement [as ReturnStatement] (D:\Development\unblock\node_modules\esotope-hammerhead\esotope.js:2381:25)
    at Object.generateBlockStatement [as BlockStatement] (D:\Development\unblock\node_modules\esotope-hammerhead\esotope.js:1812:32)
    at generateFunctionBody (D:\Development\unblock\node_modules\esotope-hammerhead\esotope.js:731:28)
```