### PR TITLE
fix parens calculation for rhs of LogicalExpression

### DIFF
--- a/esotope.js
+++ b/esotope.js
@@ -1017,7 +1017,7 @@ function generateLogicalOrBinaryExpression ($expr, settings, $parent) {
 
     operandGenSettings.precedence++;
 
-    var rightJs = exprToJs($expr.right, operandGenSettings);
+    var rightJs = exprToJs($expr.right, operandGenSettings, $expr);
 
     //NOTE: If '/' concats with '/' or `<` concats with `!--`, it is interpreted as comment start
     if (op === '/' && rightJs.charAt(0) === '/' || op.slice(-1) === '<' && rightJs.slice(0, 3) === '!--')


### PR DESCRIPTION
adds missing reference to parent when generating right-hand side of the expression.

previously `needParensForLogicalExpression` did not have sufficient info when testing the right-hand side of `??`, generating invalid syntax without the required parentheses:
```javascript
a ?? b && c // should be (b && c)
```
This solves an issue found with TestCafe, where the following minified code would have its parentheses stripped, causing all our tests to fail with a syntax error
```javascript
i[s]=n[s]??(a&&a[s])

// transformed into:
__set$(i,s,__get$(n,s)??a&&__get$(a,s)) 
// Chrome:  Uncaught SyntaxError: missing ) after argument list
// Firefox: Uncaught SyntaxError: cannot use `??` unparenthesized within `||` and `&&` expressions

// should be transformed into:
__set$(i,s,__get$(n,s)??(a&&__get$(a,s)))
```