### PR TITLE
feat: implement private identifiers

### DIFF
--- a/esotope.js
+++ b/esotope.js
@@ -103,6 +103,7 @@ var Syntax = {
     NewExpression:            'NewExpression',
     ObjectExpression:         'ObjectExpression',
     ObjectPattern:            'ObjectPattern',
+    PrivateIdentifier:        'PrivateIdentifier',
     Program:                  'Program',
     Property:                 'Property',
     RestElement:              'RestElement',
@@ -1598,6 +1599,10 @@ var ExprRawGen = {
 
     Identifier: function generateIdentifier ($expr, precedence, flag) {
         _.js += $expr.name;
+    },
+
+    PrivateIdentifier: function generatePrivateIdentifier ($expr, precedence, flag) {
+        _.js += '#' + $expr.name;
     },
 
     ImportExpression: function generateImportExpression ($expr, settings) {


### PR DESCRIPTION
We have some code that fails to be processed by TestCafe. Unfortunately I haven't managed to create a smaller testcase from it, as some logic kicks in in `testcafe-hammerhead` that skips the processing when trying to extract the problematic code from the larger bundle.

The problematic AST:

```javascript
{
  type: 'PropertyDefinition',
  start: 416242,
  end: 416535,
  static: true,
  computed: false,
  key: Node {
    type: 'PrivateIdentifier',
    start: 416249,
    end: 416251,
    name: 'e'
  },
  value: Node {
    type: 'AssignmentExpression',
    start: 416255,
    end: 416533,
    operator: '=',
    left: Node {
      type: 'MemberExpression',
      start: 416255,
      end: 416267,
      object: [Node],
      property: [Node],
      computed: false,
      optional: false
    },
    right: Node {
      type: 'ArrayExpression',
      start: 416270,
      end: 416533,
      elements: [Array]
    }
  }
}
```


https://github.com/tc39/proposal-class-fields#private-fields
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields

Related to https://github.com/DevExpress/testcafe/issues/7275.
Related to https://github.com/DevExpress/testcafe/issues/7461.