### PR TITLE
feat: implement property definition

### DIFF
--- a/esotope.js
+++ b/esotope.js
@@ -105,6 +105,7 @@ var Syntax = {
     ObjectPattern:            'ObjectPattern',
     Program:                  'Program',
     Property:                 'Property',
+    PropertyDefinition:       'PropertyDefinition',
     RestElement:              'RestElement',
     ReturnStatement:          'ReturnStatement',
     SequenceExpression:       'SequenceExpression',
@@ -1517,6 +1518,22 @@ var ExprRawGen = {
                 ExprGen[$val.type]($val, Preset.e4);
             }
         }
+    },
+
+    PropertyDefinition: function generatePropertyDefinition ($expr) {
+        var $val  = $expr.value,
+            exprJs = $expr['static'] ? 'static' + _.optSpace : '',
+            keyJs = exprToJs($expr.key, Preset.e4);
+
+        if ($expr.computed)
+            keyJs = '[' + keyJs + ']';
+
+        _.js += exprJs + keyJs + '=' + _.optSpace;
+
+        ExprGen[$val.type]($val, Preset.e4);
+
+        if (semicolons || !settings.semicolonOptional)
+            _.js += ';';
     },
 
     ObjectExpression: function generateObjectExpression ($expr) {

--- a/esotope.js
+++ b/esotope.js
@@ -1521,9 +1521,9 @@ var ExprRawGen = {
     },
 
     PropertyDefinition: function generatePropertyDefinition ($expr) {
-        var $val  = $expr.value,
+        var $val   = $expr.value,
             exprJs = $expr['static'] ? 'static' + _.optSpace : '',
-            keyJs = exprToJs($expr.key, Preset.e4);
+            keyJs  = exprToJs($expr.key, Preset.e4);
 
         if ($expr.computed)
             keyJs = '[' + keyJs + ']';


### PR DESCRIPTION
We have some code that fails to be processed by TestCafe. Unfortunately I haven't managed to create a smaller testcase from it, as some logic kicks in in `testcafe-hammerhead` that skips the processing when trying to extract the problematic code from the larger bundle.

The problematic AST:

```javascript
{
  type: 'PropertyDefinition',
  start: 416242,
  end: 416535,
  static: true,
  computed: false,
  key: Node {
    type: 'PrivateIdentifier',
    start: 416249,
    end: 416251,
    name: 'e'
  },
  value: Node {
    type: 'AssignmentExpression',
    start: 416255,
    end: 416533,
    operator: '=',
    left: Node {
      type: 'MemberExpression',
      start: 416255,
      end: 416267,
      object: [Node],
      property: [Node],
      computed: false,
      optional: false
    },
    right: Node {
      type: 'ArrayExpression',
      start: 416270,
      end: 416533,
      elements: [Array]
    }
  }
}
```

Related to https://github.com/DevExpress/testcafe/issues/7275.
Related to https://github.com/DevExpress/testcafe/issues/7461.