### PR TITLE
feat: implement static blocks

### DIFF
--- a/esotope.js
+++ b/esotope.js
@@ -1779,6 +1779,20 @@ var ExprRawGen = {
         _.js += '`';
     },
 
+    StaticBlock: function generateStaticBlock ($expr) {
+        var $body     = $expr.body,
+            bodyCount = $body.length;
+
+        _.js += 'static ';
+        _.js += '{' + _.newline;
+
+        for (var i = 0; i < bodyCount; ++i) {
+            StmtGen[$body[i].type]($body[i], Preset.e5);
+        }
+
+        _.js += _.newline + _.indent + '}';
+    },
+
     Super: function generateSuper () {
         _.js += 'super';
     }


### PR DESCRIPTION
TestCafe fails to process bundles that contain static initialization blocks.

Example of problematic AST:

```
Node {
  type: 'StaticBlock',
  start: 220015,
  end: 220104,
  body: [
    Node {
      type: 'ExpressionStatement',
      start: 220022,
      end: 220103,
      expression: [Node]
    }
  ]
}
```

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Static_initialization_blocks