### PR TITLE
fix: property definition

### DIFF
--- a/esotope.js
+++ b/esotope.js
@@ -1529,9 +1529,14 @@ var ExprRawGen = {
         if ($expr.computed)
             keyJs = '[' + keyJs + ']';
 
-        _.js += exprJs + keyJs + '=' + _.optSpace;
+        if ($val) {
+            _.js += exprJs + keyJs + '=' + _.optSpace;
+    
+            ExprGen[$val.type]($val, Preset.e4);
+        }
+        else
+            _.js += exprJs + keyJs + _.optSpace;
 
-        ExprGen[$val.type]($val, Preset.e4);
 
         if (semicolons || !settings.semicolonOptional)
             _.js += ';';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "esotope-hammerhead",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "esotope-hammerhead",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "license": "MIT",
       "dependencies": {
         "@types/estree": "0.0.46"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esotope-hammerhead",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "",
   "main": "esotope.js",
   "files": [


### PR DESCRIPTION

When declaring a private field without a value, an error occurred in propertyDefinition.

Provide a link to the existing issue(s), if any:
[issues 2969](https://github.com/DevExpress/testcafe-hammerhead/issues/2969)





